### PR TITLE
Added flagAnnotation path to API

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get    'api/getAnnotationsByLocation' => 'api_session#getAnnotationsByLocation'
   post   'api/addAnnotation' => 'api_session#addAnnotation'
   post   'api/editAnnotation' => 'api_session#editAnnotation'
+  post   'api/flagAnnotation' => 'api_session#flagAnnotation'
   delete 'api/deleteAnnotation' => 'api_session#deleteAnnotation'
   post   'api/login' => 'api_session#login'
   delete 'api/logout' => 'api_session#logout'


### PR DESCRIPTION
We have a use case where we want to give users the ability to flag specific tags in arbitrary annotations for review. Since this shouldn't change the attribution of the original annotation, I added a new function that only adds a new tag to an existing annotation. These special tags have a different purpose field: "flagging" instead of "tagging".

Sample JSON payload:
{
  "@context": "http://www.w3.org/ns/anno.jsonld",
  "id": 24,
  "type": "Annotation",
  "motivation": "highlighting",
  "creator": {
    "type": "Person",
    "nickname": "redacted",
    "email": "a92c12a703e002b7dc3cdc3234017e2983c3549d"
  },
  "body": [
    {
      "type": "TextualBody",
      "purpose": "flagging",
      "value": "testtag"
    }      
  ],
  "target": {
    "id": "http://mediaecology.dartmouth.edu/other/KTLAEulaLove.mp4",
    "type": "Video",
    "selector": [
      {
        "type": "FragmentSelector",
        "conformsTo": "http://www.w3.org/TR/media-frags/",
        "value": "t=0.0,12.0"
      }
    ]
  }
}

This will create a special tag that's a concatenation of the static slug "FlaggedItem", the tag value being flagged, and the flagging user's email address.

A future iteration of this might replace the concatenated data with a different tag object, with purpose "flagging" and the creator as separate fields. For now I'm sticking with this so we don't have to change Waldorf.js too much. (The API calls to flag a term are coming from outside Waldorf.) Because this is kind of hackish, I'm not adding flagAnnotation to the docs.